### PR TITLE
Fix: update ips docs

### DIFF
--- a/ips/README.md
+++ b/ips/README.md
@@ -12,10 +12,9 @@ The following **components** are defined:
 
 The following **functions** are possible:
 * `create` - Create a new IP Set
-* `change_owner` - Change the owner of a Set
+* `send` - Transfer IP Set owner account address
 * `list` - List an IP Set for sale
 * `buy` - Buy an IP Set
-* `send` - Transfer IP Set owner account address
 * `destroy` - Delete an IP Set and all of its contents
 
 # IP Set

--- a/ips/src/lib.rs
+++ b/ips/src/lib.rs
@@ -11,12 +11,9 @@
 //! ### Pallet Functions
 //!
 //! - `create` - Create a new IP Set
-//! - `change_owner` - Change the owner of an IP Set
-//! - `mint` - Mint a new IPT inside ab IP Set
-//! - `burn` - Burn IPT(intellectual property token)
+//! - `send` - Transfer IP Set owner account address
 //! - `list` - List an IP Set for sale
 //! - `buy` - Buy an IP Set
-//! - `send` - Transfer IP Set owner account address
 //! - `destroy` - Delete an IP Set and all of its contents
 
 #![cfg_attr(not(feature = "std"), no_std)]


### PR DESCRIPTION
- Remove `mint` and `burn` function in ips lib comments
- Remove `change_owner` redundancy with `send` function in ips docs