### PR TITLE
Feat: Add get-balance function in ipo pallet

### DIFF
--- a/ipo/Cargo.toml
+++ b/ipo/Cargo.toml
@@ -11,6 +11,7 @@ version = '0.1.0-dev'
 [dependencies]
 serde = { version = "1.0.124", optional = true }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false }
+scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 
@@ -31,6 +32,7 @@ default = ["std"]
 std = [
 	"serde",
 	"codec/std",
+	"scale-info/std",
 	"sp-runtime/std",
 	"sp-std/std",
 	"frame-support/std",

--- a/ipo/src/lib.rs
+++ b/ipo/src/lib.rs
@@ -348,6 +348,10 @@ impl<T: Config> Pallet<T> {
     fn account(who: &T::AccountId) -> AccountData<T::Balance> {
         T::AccountStore::get(who)
     }
+
+    // TODO: WIP
+    // Redundancy with get_balance from storage in line #156
+    // Should we remove get free and reserved balance and just use get_balance from storage above?
 }
 
 // TODO: WIP


### PR DESCRIPTION
- Add  get `free_balance`, `reserved_balance` and `account` balance functions
- [Need help] There's reducancy from `get_balance` function from storage in line #156. Should we just stick to the `get_balance` from storage?