### PR TITLE
Adding IpsData type so it defines traits

### DIFF
--- a/ips/src/lib.rs
+++ b/ips/src/lib.rs
@@ -55,6 +55,8 @@ pub mod pallet {
         type MaxIpsMetadata: Get<u32>;
         /// Currency
         type Currency: Currency<Self::AccountId>;
+
+        type IpsData: IntoIterator + Clone;
     }
 
     pub type BalanceOf<T> =

--- a/ips/src/mock.rs
+++ b/ips/src/mock.rs
@@ -82,6 +82,7 @@ impl Config for Runtime {
     type IpsId = u64;
     type MaxIpsMetadata = MaxIpsMetadata;
     type Currency = Balances;
+    type IpsData = Vec<<Runtime as ipt::Config>::IptId>;
 }
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;


### PR DESCRIPTION
This PR defines the traits for the IpsData type, this way it's better defined in regards to what the type should be in the runtime.